### PR TITLE
Some pages don't load properly due to inline loading

### DIFF
--- a/inline-media-type/inline-media-type.js
+++ b/inline-media-type/inline-media-type.js
@@ -36,6 +36,7 @@
             responseHeaders: details.responseHeaders
         };
     }, {
-        urls: ['<all_urls>']
+        urls: ['<all_urls>'],
+		types: ["main_frame", "sub_frame"]
     }, ['blocking', 'responseHeaders']);
 }());


### PR DESCRIPTION
I had noticed that Apple.com's main menu was not loading the text for a while and assumed it was a bug at Apple or in Chrome, but after disabling this extension, it works. I assume this extension tries to render all web requests inline, but perhaps it should be for all non-XHR requests. Perhaps something like this in the RequestFilter section of chrome.webRequest.onHeadersReceived.addListener:

``` javascript
types: ["main_frame", "sub_frame"]
```

I modified my local version of the extension and added that and it resolved the issue. Here's the change that fixes it.
