### PR TITLE
Set `Content-Disposition` to `inline` for *all* xml/json documents...

### DIFF
--- a/inline-media-type/inline-media-type.js
+++ b/inline-media-type/inline-media-type.js
@@ -3,8 +3,9 @@
     "use strict";
 
     chrome.webRequest.onHeadersReceived.addListener(function(details) {
-        var mediaType,
-            RE = /(.*\+(json|xml))(;?.*)/;
+        var mediaType = false,
+            RE_INLINE = /(.*(json|xml))(;?.*)/,
+            RE_VENDOR = /(.*\+(json|xml))(;?.*)/;
 
         // Change Content-Type to "parent" media type
         // and add current content-type as a profile to the "parent" one
@@ -12,12 +13,14 @@
             var name = header.name.toLowerCase();
 
             if (name === 'content-type') {
-                if (RE.test(header.value)) {
-                    mediaType = true;
+                if (RE_VENDOR.test(header.value)) {
                     window.console.log('Changed Content-Type for request: ' + details.url);
                     window.console.log('from: ' + header.value);
                     header.value = header.value.replace(RE, 'application/$2; profile=$1$3');
                     window.console.log('to: ' + header.value);
+                }
+                if (RE_INLINE.test(header.value)) {
+                    mediaType = true;
                 }
             }
         });

--- a/inline-media-type/inline-media-type.js
+++ b/inline-media-type/inline-media-type.js
@@ -3,8 +3,8 @@
     "use strict";
 
     chrome.webRequest.onHeadersReceived.addListener(function(details) {
-        var mediaType = false,
-            RE_INLINE = /(.*(json|xml))(;?.*)/,
+        var mediaType,
+            RE_INLINE = /.*(json|xml)/,
             RE_VENDOR = /(.*\+(json|xml))(;?.*)/;
 
         // Change Content-Type to "parent" media type
@@ -13,14 +13,15 @@
             var name = header.name.toLowerCase();
 
             if (name === 'content-type') {
-                if (RE_VENDOR.test(header.value)) {
-                    window.console.log('Changed Content-Type for request: ' + details.url);
-                    window.console.log('from: ' + header.value);
-                    header.value = header.value.replace(RE, 'application/$2; profile=$1$3');
-                    window.console.log('to: ' + header.value);
-                }
                 if (RE_INLINE.test(header.value)) {
                     mediaType = true;
+                }
+                if (RE_VENDOR.test(header.value)) {
+                    mediaType = true;
+                    window.console.log('Changed Content-Type for request: ' + details.url);
+                    window.console.log('from: ' + header.value);
+                    header.value = header.value.replace(RE_VENDOR, 'application/$2; profile=$1$3');
+                    window.console.log('to: ' + header.value);
                 }
             }
         });


### PR DESCRIPTION
otherwise Documents with non-Vendor `Content-Type` `application/json` or `application/xml` are downloaded when their `Content-Disposition` is not set to `inline`.
